### PR TITLE
Adds default APT/YUM repositories into filebeat_pkg state

### DIFF
--- a/.kitchen-docker.yml
+++ b/.kitchen-docker.yml
@@ -31,6 +31,7 @@ suites:
         filebeat.sls:
           filebeat:
             enabled: true
+            repo_managed: true
 
   - name: custom
     provisioner:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -31,6 +31,7 @@ suites:
         filebeat.sls:
           filebeat:
             enabled: true
+            repo_managed: true
 
   - name: custom
     provisioner:

--- a/filebeat/defaults.yaml
+++ b/filebeat/defaults.yaml
@@ -4,3 +4,4 @@
 filebeat:
   enabled: false
   pkg: 'filebeat'
+  major_version: 5

--- a/filebeat/defaults.yaml
+++ b/filebeat/defaults.yaml
@@ -3,5 +3,6 @@
 
 filebeat:
   enabled: false
+  repo_managed: false
   pkg: 'filebeat'
   major_version: 5

--- a/filebeat/install.sls
+++ b/filebeat/install.sls
@@ -4,5 +4,30 @@
 {%- from "filebeat/map.jinja" import filebeat with context %}
 
 filebeat_pkg:
+{% if salt['grains.get']('os_family') == 'Debian' %}
+  pkgrepo.managed:
+    - name: deb https://artifacts.elastic.co/packages/{{ filebeat.major_version }}.x/apt stable main
+    - humanname: Elastic Repository
+    - file: /etc/apt/sources.list.d/elastic-{{ filebeat.major_version }}.x.list
+    - gpgcheck: 1
+    - key_url: https://artifacts.elastic.co/GPG-KEY-elasticsearch
+    - require_in:
+      - pkg: {{ filebeat.pkg }}
+    - watch_in:
+      - pkg: {{ filebeat.pkg }}
+
+{% elif salt['grains.get']('os_family') == 'RedHat' %}
+  pkgrepo.managed:
+    - name: elastic-{{ filebeat.major_version }}.x
+    - humanname: Elastic Repository
+    - baseurl: https://artifacts.elastic.co/packages/{{ filebeat.major_version }}.x/yum
+    - gpgcheck: 1
+    - gpgkey: https://packages.elastic.co/GPG-KEY-elasticsearch
+    - require_in:
+      - pkg: {{ filebeat.pkg }}
+    - watch_in:
+      - pkg: {{ filebeat.pkg }}
+{% endif %}
+
   pkg.installed:
     - name: {{ filebeat.pkg }}

--- a/filebeat/install.sls
+++ b/filebeat/install.sls
@@ -3,31 +3,26 @@
 # How to install filebeat
 {%- from "filebeat/map.jinja" import filebeat with context %}
 
-filebeat_pkg:
+{% if filebeat.repo_managed %}
+filebeat_pkgrepo:
+  pkgrepo.managed:
 {% if salt['grains.get']('os_family') == 'Debian' %}
-  pkgrepo.managed:
     - name: deb https://artifacts.elastic.co/packages/{{ filebeat.major_version }}.x/apt stable main
-    - humanname: Elastic Repository
     - file: /etc/apt/sources.list.d/elastic-{{ filebeat.major_version }}.x.list
-    - gpgcheck: 1
     - key_url: https://artifacts.elastic.co/GPG-KEY-elasticsearch
-    - require_in:
-      - pkg: {{ filebeat.pkg }}
-    - watch_in:
-      - pkg: {{ filebeat.pkg }}
-
 {% elif salt['grains.get']('os_family') == 'RedHat' %}
-  pkgrepo.managed:
     - name: elastic-{{ filebeat.major_version }}.x
-    - humanname: Elastic Repository
     - baseurl: https://artifacts.elastic.co/packages/{{ filebeat.major_version }}.x/yum
-    - gpgcheck: 1
     - gpgkey: https://packages.elastic.co/GPG-KEY-elasticsearch
+{% endif %}
+    - humanname: Elastic Repository
+    - gpgcheck: 1
     - require_in:
       - pkg: {{ filebeat.pkg }}
     - watch_in:
       - pkg: {{ filebeat.pkg }}
 {% endif %}
 
+filebeat_pkg:
   pkg.installed:
     - name: {{ filebeat.pkg }}

--- a/pillar-custom.sls
+++ b/pillar-custom.sls
@@ -3,6 +3,7 @@
 
 filebeat:
   enabled: true
+  repo_managed: true
   config:
     filebeat:
       prospectors:

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -3,13 +3,24 @@ require 'serverspec'
 # Required by serverspec
 set :backend, :exec
 
-describe file('/etc/apt/sources.list.d/elastic-5.x.list') do
-  it { should exist }
-  it { should be_file }
-  it { should be_owned_by 'root' }
-  it { should be_grouped_into 'root' }
-  it { should be_mode 644 }
-  its(:content) { should match /^deb https:\/\/artifacts\.elastic\.co\/packages\/5\.x\/apt stable main/ }
+if os['family'] == 'debian'
+    describe file('/etc/apt/sources.list.d/elastic-5.x.list') do
+      it { should exist }
+      it { should be_file }
+      it { should be_owned_by 'root' }
+      it { should be_grouped_into 'root' }
+      it { should be_mode 644 }
+      its(:content) { should match /^deb https:\/\/artifacts\.elastic\.co\/packages\/5\.x\/apt stable main/ }
+    end
+elsif os['family'] == 'redhat'
+    describe file('/etc/yum.repos.d/elastic-5.x') do
+      it { should exist }
+      it { should be_file }
+      it { should be_owned_by 'root' }
+      it { should be_grouped_into 'root' }
+      it { should be_mode 644 }
+      its(:content) { should match /^https:\/\/artifacts\.elastic\.co\/packages\/5\.x\/yum/ }
+    end
 end
 
 describe package('filebeat') do

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -3,6 +3,15 @@ require 'serverspec'
 # Required by serverspec
 set :backend, :exec
 
+describe file('/etc/apt/sources.list.d/elastic-5.x.list') do
+  it { should exist }
+  it { should be_file }
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into 'root' }
+  it { should be_mode 644 }
+  its(:content) { should match /^deb https:\/\/artifacts\.elastic\.co\/packages\/5\.x\/apt stable main/ }
+end
+
 describe package('filebeat') do
   it { should be_installed }
 end

--- a/test/mockup/init.sls
+++ b/test/mockup/init.sls
@@ -8,6 +8,14 @@ filebeat_mockup_deps:
     - pkgs:
       - haveged
 
+filebeat_repo_managed:
+  pkgrepo.managed:
+    - humanname: Elasticsearch Repo
+    - name: deb https://artifacts.elastic.co/packages/5.x/apt stable main
+    - dist: stable
+    - file: /etc/apt/sources.list.d/elastic-5.x.list
+    - key_url: https://artifacts.elastic.co/GPG-KEY-elasticsearch
+
 jessie_backports_repo_managed:
   pkgrepo.managed:
     - humanname: Jessie Backports

--- a/test/mockup/init.sls
+++ b/test/mockup/init.sls
@@ -15,7 +15,7 @@ filebeat_repo_managed:
     - dist: stable
     - file: /etc/apt/sources.list.d/elastic-5.x.list
     - key_url: https://artifacts.elastic.co/GPG-KEY-elasticsearch
-
+    
 jessie_backports_repo_managed:
   pkgrepo.managed:
     - humanname: Jessie Backports

--- a/test/mockup/init.sls
+++ b/test/mockup/init.sls
@@ -8,14 +8,6 @@ filebeat_mockup_deps:
     - pkgs:
       - haveged
 
-filebeat_repo_managed:
-  pkgrepo.managed:
-    - humanname: Elasticsearch Repo
-    - name: deb https://artifacts.elastic.co/packages/5.x/apt stable main
-    - dist: stable
-    - file: /etc/apt/sources.list.d/elastic-5.x.list
-    - key_url: https://artifacts.elastic.co/GPG-KEY-elasticsearch
-    
 jessie_backports_repo_managed:
   pkgrepo.managed:
     - humanname: Jessie Backports

--- a/test/mockup/init.sls
+++ b/test/mockup/init.sls
@@ -8,8 +8,10 @@ filebeat_mockup_deps:
     - pkgs:
       - haveged
 
-jessie_backports_repo_managed:
+{% if salt['grains.get']('os_family') == 'Debian' %}
+stretch_backports_repo_managed:
   pkgrepo.managed:
-    - humanname: Jessie Backports
-    - name: deb http://ftp.debian.org/debian jessie-backports main
-    - file: /etc/apt/sources.list.d/jessie-backports.list
+    - humanname: Stretch Backports
+    - name: deb http://ftp.debian.org/debian stretch-backports main
+    - file: /etc/apt/sources.list.d/stretch-backports.list
+{% endif %}


### PR DESCRIPTION
Adding the package repositories into the `filebeat_pkg` state allows this formula to work "out of the box".